### PR TITLE
allow multithreaded init

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,23 +17,146 @@
 // <http://www.gnu.org/licenses/>.
 extern crate guile_sys;
 
-use std::ffi::{self, c_char, c_void};
+use std::{
+    ffi::{self, c_char, c_void},
+    ptr,
+    sync::{
+        atomic::{self, AtomicBool},
+        Mutex,
+    },
+    thread_local,
+};
+
+/// Lock for global initalization since guile cannot initialize multiple threads at the same time.
+static INITIALIZATION_LOCK: Mutex<()> = Mutex::new(());
+
+thread_local! {
+    /// Whether or not the current thread has been initialized.
+    static INITIALIZED: AtomicBool = const { AtomicBool::new(false) };
+    /// Whether or not the current thread is currently in guile mode.
+    static GUILE_MODE: AtomicBool = const { AtomicBool::new(false) };
+}
 
 pub struct GuileVM {}
 
-pub fn init<F>(func: F)
+// TODO: link documentation once catching and dynwind is implemented
+/// Attempt to run `func` with access to the guile vm.
+///
+/// # Non-local exits
+///
+/// The result of the function will only be returned if it has not exitted non-locally in guile.
+///
+/// This would only apply to the top level guile mode entry point. If you would like to protect against
+/// non-local exits, consider using a catch block or dynwind.
+///
+/// # Examples
+///
+/// ```
+/// # use guile::GuileVM;
+/// # // TODO: create and use safe abstractions for theses
+/// # use guile_sys::{scm_throw, scm_from_utf8_symbol, scm_make_list, scm_from_uint8};
+/// fn intentional_throw(_: &GuileVM) -> ! {
+///     // SAFETY: bindgen should provide the correct type signatures, making this safe.
+///     // SAFETY: the guile vm is proof of being in guile mode.
+///     let zero = unsafe { scm_from_uint8(0) };
+///     unsafe {
+///         scm_throw(scm_from_utf8_symbol(c"foo".as_ptr()), scm_make_list(zero, zero));
+///     }
+///     unreachable!()
+/// }
+/// assert_eq!(guile::init(|_| {}), Some(()));
+/// assert_eq!(guile::init(|vm| {
+///     intentional_throw(vm)
+/// }), None);
+/// assert_eq!(guile::init(|guile| {
+///     drop(guile); // oops
+///
+///     assert_eq!(guile::init(|vm| {
+///         intentional_throw(vm)
+///     }), unreachable!("this never gets ran"));
+/// }), None, "the throw should be caught here");
+/// ```
+pub fn init<F, O>(func: F) -> Option<O>
 where
-    F: Fn(GuileVM),
+    F: FnOnce(&mut GuileVM) -> O,
 {
-    unsafe {
-        guile_sys::scm_with_guile(
-            Some(with_guile_callback::<F>),
-            &func as *const _ as *mut c_void,
-        );
+    if GUILE_MODE.with(|local_init| local_init.load(atomic::Ordering::Acquire)) {
+        Some(func(&mut GuileVM {}))
+    } else {
+        let _lock = INITIALIZED
+            .with(|initialized| !initialized.load(atomic::Ordering::Acquire))
+            .then(|| INITIALIZATION_LOCK.lock().unwrap());
+
+        let mut data = WithGuileCallbackData {
+            closure: Some(func),
+            output: None,
+        };
+        unsafe {
+            guile_sys::scm_with_guile(
+                Some(with_guile_callback::<F, O>),
+                (&raw mut data).cast::<c_void>(),
+            );
+        }
+
+        GUILE_MODE.with(|initialized| initialized.store(false, atomic::Ordering::Release));
+
+        data.output
     }
+}
+struct WithGuileCallbackData<F, O>
+where
+    F: FnOnce(&mut GuileVM) -> O,
+{
+    closure: Option<F>,
+    output: Option<O>,
+}
+
+/// Callback for use by [guile_sys::scm_with_guile]
+///
+/// # Safety
+///
+/// `ptr` must be a pointer of type `WithGuileCallbackData<F, O>`
+unsafe extern "C" fn with_guile_callback<F, O>(ptr: *mut c_void) -> *mut c_void
+where
+    F: FnOnce(&mut GuileVM) -> O,
+{
+    INITIALIZED.with(|local_init| local_init.store(true, atomic::Ordering::Release));
+    GUILE_MODE.with(|local_init| local_init.store(true, atomic::Ordering::Release));
+
+    let data = ptr.cast::<WithGuileCallbackData<F, O>>();
+    if let Some(data) = unsafe { data.as_mut() } {
+        data.output = data
+            .closure
+            .take()
+            .map(|closure| (closure)(&mut GuileVM {}));
+    }
+
+    ptr::null_mut()
 }
 
 impl GuileVM {
+    /// Run a blocking operation without impacting garbage collection.
+    pub fn block<F, O>(&mut self, operation: F) -> O
+    where
+        F: FnOnce() -> O,
+    {
+        let mut data = WithoutGuileCallbackData {
+            operation: Some(operation),
+            output: None,
+        };
+
+        unsafe {
+            guile_sys::scm_without_guile(
+                Some(without_guile_callback::<F, O>),
+                (&raw mut data).cast(),
+            );
+        }
+
+        GUILE_MODE.with(|local_init| local_init.store(true, atomic::Ordering::Release));
+
+        data.output.unwrap()
+    }
+
     pub fn shell(&self, args: Vec<String>) {
         unsafe {
             let mut argv: Vec<*mut c_char> = args
@@ -46,22 +169,49 @@ impl GuileVM {
     }
 }
 
-unsafe extern "C" fn with_guile_callback<F>(data: *mut c_void) -> *mut c_void
+struct WithoutGuileCallbackData<F, O>
 where
-    F: Fn(GuileVM),
+    F: FnOnce() -> O,
 {
-    let callback = data as *mut F;
+    operation: Option<F>,
+    output: Option<O>,
+}
+unsafe extern "C" fn without_guile_callback<F, O>(data: *mut c_void) -> *mut c_void
+where
+    F: FnOnce() -> O,
+{
+    GUILE_MODE.with(|local_init| local_init.store(false, atomic::Ordering::Release));
 
-    let vm = GuileVM {};
+    let data = data.cast::<WithoutGuileCallbackData<F, O>>();
+    if let Some(data) = unsafe { data.as_mut() } {
+        data.output = data.operation.take().map(|operation| (operation)());
+    }
 
-    (*callback)(vm);
-
-    std::ptr::null_mut()
+    ptr::null_mut()
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn in_and_out() {
+        assert!(init(|api| api.block(|| init(|_| true))).unwrap().unwrap());
+    }
+
+    #[test]
+    fn multi_threading() {
+        let spawn_thread = || std::thread::spawn(|| init(|_| {}).unwrap());
+        let (thread_1, thread_2) = (spawn_thread(), spawn_thread());
+
+        thread_1.join().unwrap();
+        thread_2.join().unwrap();
+    }
+
+    #[test]
+    fn mutex_deadlock() {
+        assert!(init(|_| init(|_| true)).unwrap().unwrap());
+    }
 
     #[test]
     fn it_works() {


### PR DESCRIPTION
Guile has a bug where it cannot initialize multiple threads. See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=79100.

This pr will add a fix for older versions where we lock threads initialization behind mutexes.

The fix could potentially configured out through feature flags.

Fixes: #37
