### PR TITLE
remove libc from dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,6 @@ name = "guile"
 version = "0.0.3"
 dependencies = [
  "guile-sys",
- "libc",
 ]
 
 [[package]]
@@ -82,7 +81,6 @@ name = "guile-sys"
 version = "0.1.1"
 dependencies = [
  "bindgen",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ license = "GPL-3.0"
 edition = "2021"
 
 [dependencies]
-libc = "0.2.175"
 
 [dependencies.guile-sys]
 path = "guile-sys"

--- a/guile-sys/Cargo.toml
+++ b/guile-sys/Cargo.toml
@@ -15,7 +15,6 @@ name = "guile_sys"
 path = "src/lib.rs"
 
 [dependencies]
-libc = "0.2"
 
 [build-dependencies]
 bindgen = "0.69.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,8 @@
 // License along with guile-rs.  If not, see
 // <http://www.gnu.org/licenses/>.
 extern crate guile_sys;
-extern crate libc;
 
-use libc::{c_char, c_void};
-use std::ffi;
+use std::ffi::{self, c_char, c_void};
 
 pub struct GuileVM {}
 


### PR DESCRIPTION
This crate currently has a dependency on libc for c types which are now in `core`.

This will increase the MSRV.
